### PR TITLE
PSR-1 naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.ini
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "illblew/php-linode-unofficial",
+    "type": "library",
+    "description": "Unofficial Linode API v4 wrapper",
+    "keywords": ["linode"],
+    "homepage": "https://github.com/illblew/php-linode-unofficial",
+    "authors": [
+        {
+            "name": "Will Blew",
+            "email": "wblew@linode.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Linode\\": "lib/"
+        }
+    },
+    "require": {
+        "php": ">=5.2.0",
+        "ext-curl": "*",
+        "ext-json": "*"
+    }
+}

--- a/example/.htaccess
+++ b/example/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]

--- a/example/index.php
+++ b/example/index.php
@@ -1,15 +1,13 @@
 <?php
-require __DIR__ . '/../lib/Common/ConfigManager.php';
-require __DIR__ . '/../lib/Auth/core.php';
+require 'vendor/autoload.php';
 
-
-$configFile = '/path/to/config.ini'; // Target config to use
-$configManager = new ConfigManager;
+$configFile = 'config.ini'; // Target config to use
+$configManager = new Linode\Common\ConfigManager;
 $config = $configManager->loadConfig($configFile); // Load the config
 
 //You need to have your callback provide the code or just use a token as provided in the oAuth page.
 if($_GET['auth'] == 1 && isset($_GET['code'])) {
-                $myAuth = new Auth;
+                $myAuth = new Linode\Auth\Core;
                 $code = $_GET['code']; // Get the code from url, these examples are just for testing.
                 $myToken[] = $myAuth->GetAuth($config['baseoauth'],$config['clientid'],$config['clientsecret'],$code);
                 echo json_encode($myToken[0]);
@@ -19,4 +17,3 @@ if($_GET['auth'] == 1 && isset($_GET['code'])) {
                 echo "You need to provide a code to get a token!";
         }
 
-?>

--- a/lib/Auth/Core.php
+++ b/lib/Auth/Core.php
@@ -1,8 +1,9 @@
 <?php
+namespace Linode\Auth;
 
-require __DIR__ . '/../Common/Curl.php';
+use Linode\Common\Curl;
 
-class Auth {
+class Core {
 
     function GetAuth($endpoint,$clientId,$clientSecret,$code) {
         $curl = new Curl;
@@ -15,5 +16,3 @@ class Auth {
         return $authCurl;
     }
 }
-
-?>

--- a/lib/Common/ConfigManager.php
+++ b/lib/Common/ConfigManager.php
@@ -1,6 +1,8 @@
 <?php
+namespace Linode\Common;
+
 class ConfigManager {
-    function loadConfig($configFile) {
+    public function loadConfig($configFile) {
         try {
             $config = parse_ini_file($configFile);
             $clientsecret = $config['clientsecret'];
@@ -15,4 +17,3 @@ class ConfigManager {
         }
     }
 }
-?>

--- a/lib/Common/Curl.php
+++ b/lib/Common/Curl.php
@@ -1,6 +1,8 @@
 <?php
+namespace Linode\Common;
+
 class Curl {
-    function CurlPost($endpoint,$header, $post) {
+    public function CurlPost($endpoint,$header, $post) {
         $ch = curl_init();
         $values = array(
             CURLOPT_URL => $endpoint,
@@ -13,7 +15,7 @@ class Curl {
         return $response;
     }
 
-    function CurlGet($endpoint) {
+    public function CurlGet($endpoint) {
         $ch = curl_init();
         curl_setopt_array($ch, array(
             CURLOPT_RETURNTRANSFER =>1,
@@ -25,4 +27,3 @@ class Curl {
 
     }
 }
-?>


### PR DESCRIPTION
Adopt [PSR-1 class naming conventions](http://www.php-fig.org/psr/psr-1/#3-namespace-and-class-names) and provide a [composer.json](https://getcomposer.org/doc/00-intro.md) for future use on [packagist](https://packagist.org/).

Also moved the docs/example to example/ as it may be [easier to serve for demos](https://github.com/slimphp/Slim/tree/3.x/example).

To mess with this in the project root:

``` bash
cp config.ini.example config.ini
vi config.ini
ln -s example/index.php
# getcomposer.org
composer.phar install .
php -S 0.0.0.0:8080
```
