### PR TITLE
updated the example and related endpoints for API changes

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -2,19 +2,52 @@
 
 require '../vendor/autoload.php';
 
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+
+error_reporting(E_ALL);
+
 $configManager = new Linode\Common\ConfigManager();
 $config = $configManager->loadConfig(); // Load the config
 
 if (!empty($config['token'])) {
-    echo 'Your config and token have been loaded for use. See below for example calls you can make!<BR><BR><h3>Get Instances</h3>';
-    echo '$Instances = new Linode\Instances\Instances();<BR>';
-    echo '$Instances->getLinodes();';
-    echo '<BR><BR><h3>Create a Linode</h3>';
-    echo '$create = new Linode\Instances\Instances();<BR>';
-    echo '$create->createLinode("newark","standard-1","coolName","coolGroup",null,"CoolPassword!",null,null,null,null,"true");<BR><BR>';
+    echo 'Your config and token have been loaded for use. See below for example calls you can make!<BR><BR>'."\n";
+    echo '<h3>Get Instances</h3>'."\n";
+    echo '<pre>'."\n";
+    echo '$Datacenters = new Linode\Common\Datacenters();'."\n";
+    echo '$Datacenters->getDatacenters();'."\n";
+    $Datacenters = new Linode\Common\Datacenters();
+    $dcs = $Datacenters->getDatacenters();
+    var_dump($dcs);
+    echo '</pre>'."\n";
 
-    echo '//todo replace with real docs';
+    echo '<h3>Get Instances</h3>'."\n";
+    echo '<pre>'."\n";
+    echo '$Instances = new Linode\Instances\Instances();<BR>'."\n";
+    echo '$Instances->getLinodes();'."\n";
+    $Instances = new Linode\Instances\Instances();
+    $linodes = $Instances->getLinodes();
+    var_dump($linodes);
+    echo '</pre>'."\n";
+
+
+    echo '<BR><BR><h3>Create a Linode</h3>'."\n";
+    echo '<pre>'."\n";
+    echo '$create = new Linode\Instances\Instances();<BR>'."\n";
+    $cool_password = uniqid();
+    echo '$create->createLinode("us-east-1a","g5-nanode-1","coolName","coolGroup",null,"'.$cool_password.'",null,null,null,null,"true");<BR><BR>'."\n";
+    $Instances = new Linode\Instances\Instances();
+    $linode = $Instances->createLinode("us-east-1a","g5-nanode-1","coolName","coolGroup",null,$cool_password,null,null,null,null,"true");
+    var_dump($linode);
+
+    $linode_deleted = $Instances->deleteLinode($linode->id);
+    var_dump($linode_deleted);
+    echo '</pre>'."\n";
+
+    echo '//todo replace with real docs'."\n";
 
 } else {
-    echo "You didn't provide a token in your config! Provide it or pass a code to set one.";
+    echo "You didn't provide a token in your config! Provide it or pass a code to set one.\n";
 }
+
+

--- a/lib/Common/ConfigManager.php
+++ b/lib/Common/ConfigManager.php
@@ -6,8 +6,9 @@ class ConfigManager
 {
     public function loadConfig()
     {
+	$config_file = getenv('PHP_LINODE_INI')?:__DIR__."/../../config.ini";
         try {
-            $config = parse_ini_file('/path/to/config.ini');
+            $config = parse_ini_file($config_file);
             $clientsecret = $config['clientsecret'];
             $clientid = $config['clientid'];
             $baseoauth = $config['baseoauth'];

--- a/lib/Common/Curl.php
+++ b/lib/Common/Curl.php
@@ -4,6 +4,7 @@ namespace Linode\Common;
 
 class Curl
 {
+    const USER_AGENT = 'PHP-Linode-V4/1.0';
     public function curlPost($endpoint, $headers, $post)
     {
         $ch = curl_init();
@@ -11,23 +12,51 @@ class Curl
             CURLOPT_URL => $endpoint,
             CURLOPT_POST => 1,
             CURLOPT_POSTFIELDS => $post,
-            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_RETURNTRANSFER => 1,
+	    CURLOPT_HTTPHEADER => $headers,
+	    CURLOPT_USERAGENT => self::USER_AGENT,
         );
-        curl_setopt($ch,CURLOPT_HTTPHEADER, $headers);
-        curl_setopt_array($ch, ($values));
+        curl_setopt_array($ch, $values);
         $response = curl_exec($ch);
+	curl_close($ch);
+	$response = json_decode($response);
+        return $response;
+    }
+
+    public function curlDelete($endpoint, $headers)
+    {
+        $ch = curl_init();
+        $values = array(
+            CURLOPT_URL => $endpoint,
+	    CURLOPT_RETURNTRANSFER => 1,
+	    CURLOPT_CUSTOMREQUEST => "DELETE",
+            CURLOPT_HTTPHEADER => $headers,
+	    CURLOPT_USERAGENT => self::USER_AGENT,
+        );
+        curl_setopt_array($ch, $values);
+	$response = curl_exec($ch);
+	curl_close($ch);
+	$response = json_decode($response);
         return $response;
     }
 
     public function curlGet($endpoint, $token)
     {
-        $ch = curl_init();
+	$ch = curl_init();
+	$values = array(
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_URL => $endpoint,
+	    CURLOPT_USERAGENT => self::USER_AGENT,
+	);
+
         if (!empty($token)) {
             $headers = array('Authorization: token ' . $token);
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+	    $values[CURLOPT_HTTPHEADER] = $headers;
         }
-        curl_setopt($ch, CURLOPT_URL, $endpoint);
-        $response = curl_exec($ch);
+        curl_setopt_array($ch, $values);
+	$response = curl_exec($ch);
+	curl_close($ch);
+	$response = json_decode($response);
         return $response;
     }
 }

--- a/lib/Common/Datacenters.php
+++ b/lib/Common/Datacenters.php
@@ -2,7 +2,7 @@
 
 namespace Linode\Common;
 
-use Linode\Common\Curl;
+use Linode\Auth\Core;
 
 class Datacenters extends Core
 {
@@ -12,8 +12,8 @@ class Datacenters extends Core
         $curl = new Curl();
         $apiUrl = $this->getApiUrl();
         $token = $this->getTokenAuth();
-        $fullUrl = $apiUrl . 'datacenters';
-        $kernels = $curl->curlGet($fullUrl,$token);
+        $fullUrl = $apiUrl . 'regions';
+        $datacenters = $curl->curlGet($fullUrl,$token);
         return $datacenters;
     }
 

--- a/lib/Instances/Instances.php
+++ b/lib/Instances/Instances.php
@@ -25,12 +25,23 @@ class Instances extends Core
         $apiUrl = $this->getApiUrl();
         $token = $this->getTokenAuth();
         $fullUrl = $apiUrl . 'linode/instances';
-        $arr = array("datacenter" => $datacenter, "type" => $type, "label" => $label, "group" => $group, "distro" => $distro, "root_pass" => $root_pass, "root_ssh_key" => $root_ssh_key, "stackscript" => $stackscript, "stackscript_udf_responses" => $stackscript_udf_responses, "backup" => $backup, "with_backups" => $with_backup);
+        $arr = array("region" => $datacenter, "type" => $type, "label" => $label, "group" => $group, "distro" => $distro, "root_pass" => $root_pass, "root_ssh_key" => $root_ssh_key, "stackscript" => $stackscript, "stackscript_udf_responses" => $stackscript_udf_responses, "backup" => $backup, "with_backups" => $with_backup);
         $post = json_encode($arr);
         $header = array ('Content-Type: application/json', 'Authorization: token ' . $token);
         $instance = $curl->curlPost($fullUrl,$header,$post);
         return $instance;
 
+    }
+
+    //Delete a Linode Instance.
+    public function deleteLinode($id) {
+        $curl = new Curl();
+        $apiUrl = $this->getApiUrl();
+        $token = $this->getTokenAuth();
+        $fullUrl = $apiUrl . "linode/instances/".((int)$id);
+        $header = array ('Content-Type: application/json', 'Authorization: token ' . $token);
+        $instance = $curl->curlDelete($fullUrl,$header);
+        return $instance;
     }
 
 }


### PR DESCRIPTION
* Added deleteLinode and more examples.  
* Updated some API endpoints that have changed from alpha.  
* Changed the URLs to use non-alpha.
* Can now be invoked at the command line:
    ```
    examples$ php -d include_path=`pwd`/example index.php
    ```